### PR TITLE
Remove Reload / Added Localization / Accounted for OS when using ctrlKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Version 1.4.0
+- Removed need to reload window after toggling Override Status
+- Added Localization
+- Adjusted logic to handle ctrlKey and metaKey to account for OS, as if on windows users using the ctrl key would also allow the windows key.

--- a/disable-mouse-wheel-sliders.js
+++ b/disable-mouse-wheel-sliders.js
@@ -9,14 +9,11 @@ const MODULEID = 'disable-mouse-wheel-sliders'
 // Store Foundry's original function for later use
 let originalHandleMouseWheelInputChange = Game._handleMouseWheelInputChange;
 
-function useDefaultBehavior(event) {
-  // Get if OS is Mac
-  // ! navigator.platform is deprecated, but navigator.userAgentData.platform is not supported in Firefox, Safari or HTTP
-  const isMacOS = (navigator?.userAgentData?.platform ?? navigator?.platform ?? '').toUpperCase().indexOf('MAC') >= 0;
-  const escapeKey = game.settings.get(MODULEID, "metaKey");
 
-  // If OS is Mac and escapeKey is set to ctrlKey
-  if (isMacOS && escapeKey === "ctrlKey" && event.metaKey) return true;
+function useDefaultBehavior(event) {
+  // If setting is ctrlKey, check if ctrl or meta key is pressed
+  // otherwise return escapeKey value
+  if (escapeKey === "ctrlKey" && ((event.ctrlKey) || (event.metaKey))) return true;
   else return event?.[escapeKey] ?? false;
 }
 

--- a/disable-mouse-wheel-sliders.js
+++ b/disable-mouse-wheel-sliders.js
@@ -3,22 +3,32 @@
 * @param {WheelEvent} event    A Mouse Wheel scroll event
 */
 
-let originalHandleMouseWheelInputChange;
+// Define Module ID
+const MODULEID = 'disable-mouse-wheel-sliders'
 
-function useDefaultBehavior() {
-  switch (game.settings.get("disable-mouse-wheel-sliders", "metaKey")) {
-    case "a": return false;
-    case "b": return event.altKey;
-    case "c": return event.ctrlKey || event.metaKey;
-  }
+// Store Foundry's original function for later use
+let originalHandleMouseWheelInputChange = Game._handleMouseWheelInputChange;
+
+function useDefaultBehavior(event) {
+  // Get if OS is Mac
+  // ! navigator.platform is deprecated, but navigator.userAgentData.platform is not supported in Firefox, Safari or HTTP
+  const isMacOS = (navigator?.userAgentData?.platform ?? navigator?.platform ?? '').toUpperCase().indexOf('MAC') >= 0;
+  const escapeKey = game.settings.get(MODULEID, "metaKey");
+
+  // If OS is Mac and escapeKey is set to ctrlKey
+  if (isMacOS && escapeKey === "ctrlKey" && event.metaKey) return true;
+  else return event?.[escapeKey] ?? false;
 }
 
 function _handleMouseWheelInputChange_Override(event) {
-  if (!useDefaultBehavior()) {
-    // implementation replaced with no-op to avoid scroll wheel changing slider values
-  } else {
-    originalHandleMouseWheelInputChange(event);
-  }
+  // Get if Setting Satus
+  const overrideDefaultBehavior = game.settings.get(MODULEID, "disable-mouse-wheel-sliders");
+  
+  // If setting is off, or if setting is on but metaKey not pressed
+  if (overrideDefaultBehavior && !useDefaultBehavior(event)) return;
+  
+  // Run Fondrys original function
+  originalHandleMouseWheelInputChange(event);
 }
 
 function disableInputNumbers(event) {
@@ -38,48 +48,65 @@ function disableInputNumbers(event) {
 }
 
 Hooks.on("init", function () {
-  game.settings.register("disable-mouse-wheel-sliders", "disable-mouse-wheel-sliders", {
-    name: "Disable Sliders",
-    hint: "This disables the mouse wheel control for all sliders (e.g. the volume controls in playlists) on this client.",
+  // Define Setting to Let user toggle if module should override sliders
+  game.settings.register(MODULEID, "disable-mouse-wheel-sliders", {
+    name: `${MODULEID}.settings.disable-mouse-wheel-sliders.name`,
+    hint: `${MODULEID}.settings.disable-mouse-wheel-sliders.hint`,
     scope: "client",
     config: true,
     default: false,
     type: Boolean,
-    requiresReload: true
+    requiresReload: false,
   });
 
-  game.settings.register("disable-mouse-wheel-sliders", "disable-mouse-wheel-inputs", {
-    name: "Disable Inputs",
-    hint: "This disables the mouse wheel control for all input fields (e.g. grid units for tokens) on this client.",
+  // Define Setting to Let user toggle if module should override inputs
+  game.settings.register(MODULEID, "disable-mouse-wheel-inputs", {
+    name: `${MODULEID}.settings.disable-mouse-wheel-inputs.name`,
+    hint: `${MODULEID}.settings.disable-mouse-wheel-inputs.hint`,
     scope: "client",
     config: true,
     default: false,
     type: Boolean,
-    requiresReload: true
+    requiresReload: false,
+    // When user changes setting, add or remove Event listener to disable input numbers
+    onChange: (value) => {
+      // If enabled, add Event Listener
+      if (value) window.addEventListener("wheel", disableInputNumbers);
+      // If false, remove Event Listener
+      else window.removeEventListener("wheel", disableInputNumbers);
+    }
   });
 
-  game.settings.register("disable-mouse-wheel-sliders", "metaKey", {
-    name: "Choose Escape Key",
-    hint: "This defines an escape key. While holding this key, mouse wheel control for sliders and input fields is enabled.",
+  // if setting is on, add Event listener to disable input numbers
+  if (game.settings.get(MODULEID, "disable-mouse-wheel-inputs")) {
+    window.addEventListener("wheel", disableInputNumbers);
+  }
+
+  // Define Setting to Let user Choose Escape key for Mouse Wheel Evert
+  game.settings.register(MODULEID, "metaKey", {
+    name: `${MODULEID}.settings.metaKey.name`,
+    hint: `${MODULEID}.settings.metaKey.hint`,
     scope: "client",
     config: true,
     default: "a",
     type: String,
     choices: {
-      "a": "none",
-      "b": "alt/option",
-      "c": "ctrl/cmd"
+      "none": `${MODULEID}.settings.metaKey.choices.none`,
+      "altKey": `${MODULEID}.settings.metaKey.choices.altKey`,
+      "ctrlKey": `${MODULEID}.settings.metaKey.choices.ctrlKey`
     }
   });
+  
+  // Override Foundrys original function
+  Game._handleMouseWheelInputChange = _handleMouseWheelInputChange_Override;
 
-  // Override default Foundry function for sliders
-  if (game.settings.get("disable-mouse-wheel-sliders", "disable-mouse-wheel-sliders")) {
-    originalHandleMouseWheelInputChange = Game._handleMouseWheelInputChange;
-    Game._handleMouseWheelInputChange = _handleMouseWheelInputChange_Override;
-  };
-
-  // Override default HTML function for number inputs
-  if (game.settings.get("disable-mouse-wheel-sliders", "disable-mouse-wheel-inputs")) {
-    window.addEventListener("wheel", disableInputNumbers);
-  }
+  // Migrate Old Settings to new Settings
+  Hooks.once("ready", function () {
+    let oldSetting = game.settings.get(MODULEID, "metaKey");
+    if (['a', 'b', 'c'].includes(oldSetting)) {
+      if (oldSetting === 'a') game.settings.set(MODULEID, "metaKey", 'none');
+      else if (oldSetting === 'b') game.settings.set(MODULEID, "metaKey", 'altKey');
+      else if (oldSetting === 'c') game.settings.set(MODULEID, "metaKey", 'ctrlKey');
+    }
+  });
 });

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,0 +1,21 @@
+{
+	"disable-mouse-wheel-sliders": {
+		"title": "Disable Mouse Wheel Control for Sliders",
+		"settings":{
+			"disable-mouse-wheel-sliders.name": "Disable Sliders",
+			"disable-mouse-wheel-sliders.hint": "This disables the mouse wheel control for all sliders (e.g. the volume controls in playlists) on this client.",
+			"disable-mouse-wheel-inputs.name": "Disable Inputs",
+			"disable-mouse-wheel-inputs.hint": "This disables the mouse wheel control for all input fields (e.g. grid units for tokens) on this client.",
+			"metaKey": {
+				"name": "Choose Escape Key",
+				"hint": "This defines an escape key. While holding this key, mouse wheel control for sliders and input fields is enabled.",
+				"choices": {
+					"none": "None",
+					"altKey": "Alt (⊞) / Option (⌘)",
+					"ctrlKey": "Ctrl (⊞) / Command (⌘)",
+					"metaKey": "Window (⊞) / Command (⌘) "
+				}
+			}
+		}
+	}
+}

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "disable-mouse-wheel-sliders",
   "title": "Disable Mouse Wheel Control for Sliders",
   "description": "Adds a client-side setting that disables mouse wheel control of sliders and input fields.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "esmodules": [
     "/disable-mouse-wheel-sliders.js"
   ],
@@ -13,11 +13,31 @@
     {
       "name": "Marko Wenzel",
       "flags": {}
-    }
+    }, {
+			"name": "Mouse0270",
+			"url": "https://github.com/mouse0270/",
+			"email": "rmcintosh@websitesbyfatdudes.com",
+			"discord": "Mouse0270#0270",
+
+			"flags": {
+				"twitter": "Mouse0270",
+				"patreon": "Mouse0270",
+				"github": "Mouse0270",
+				"ko-fi": "Mouse0270",
+				"reddit": "u/Mouse0270"
+			}
+		}
   ],
   "compatibility": {
     "minimum": "0.8.5",
     "verified": "11",
     "maximum": "11"
-  }
+  },
+	"languages": [
+		{
+			"lang": "en",
+			"name": "English",
+			"path": "languages/en.json"
+		}
+	]
 }


### PR DESCRIPTION
- Removed need to reload window after toggling Override Status
- Added Localization
- Adjusted logic to handle ctrlKey and metaKey to account for OS, as if on windows users using the ctrl key would also allow the windows key.